### PR TITLE
Fix accidental sabotage of Objective-C try-catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,9 @@ module.exports = {
         if (objcThrow !== null) {
           let potentialObjCPanic = null;
 
-          Interceptor.attach(objcThrow, {
-            onEnter(args) {
-              const exception = new ObjC.Object(args[0]);
-              potentialObjCPanic = preparePanic('Unhandled Objective-C exception: ' + exception.toString(), {}, this.context);
-            }
+          Interceptor.attach(objcThrow, function (args) {
+            const exception = new ObjC.Object(args[0]);
+            potentialObjCPanic = preparePanic('Unhandled Objective-C exception: ' + exception.toString(), {}, this.context);
           });
 
           Interceptor.attach(Module.findExportByName('libsystem_c.dylib', 'abort'), {


### PR DESCRIPTION
This was turning a locally handled exception into an unhandled one.
Turns out that `objc_exception_throw()` inspects the return address as
part of the exception-handling, so we must avoid replacing it. Using an
instruction-level hook ensures the return address stays intact.
